### PR TITLE
Add minimal test framework and check_guess tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -Wall -Wextra -Itests
+
+all: ufo
+
+ufo: ufo.cpp ufo_functions.cpp
+	$(CXX) $(CXXFLAGS) ufo.cpp ufo_functions.cpp -o ufo
+
+# Build tests executable
+tests/test_check_guess: tests/test_check_guess.cpp ufo_functions.cpp
+	$(CXX) $(CXXFLAGS) tests/test_check_guess.cpp ufo_functions.cpp -o tests/test_check_guess
+
+.PHONY: test clean
+
+test: tests/test_check_guess
+	./tests/test_check_guess
+
+clean:
+	rm -f ufo tests/test_check_guess

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# UFO Game
+
+This project implements a simple UFO word-guessing game.
+
+## Building
+
+Compile the main game:
+
+```bash
+make
+```
+
+## Tests
+
+Tests are located in the `tests/` directory and use a very small Catch2-style framework.
+Run them with:
+
+```bash
+make test
+```

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#include <iostream>
+#include <vector>
+#include <functional>
+#include <exception>
+#include <string>
+
+namespace mini_catch {
+struct TestRegistry {
+    std::vector<std::pair<std::string, std::function<void()>>> tests;
+    void add(const std::string& name, std::function<void()> func) {
+        tests.push_back({name, func});
+    }
+    int run() {
+        int failures = 0;
+        for (auto& t : tests) {
+            try {
+                t.second();
+                std::cout << "[PASSED] " << t.first << "\n";
+            } catch (const std::exception& e) {
+                std::cout << "[FAILED] " << t.first << " - " << e.what() << "\n";
+                ++failures;
+            } catch (...) {
+                std::cout << "[FAILED] " << t.first << " - unknown error\n";
+                ++failures;
+            }
+        }
+        return failures;
+    }
+};
+
+inline TestRegistry& registry() {
+    static TestRegistry inst;
+    return inst;
+}
+
+struct AutoReg {
+    AutoReg(const std::string& name, std::function<void()> func) {
+        registry().add(name, func);
+    }
+};
+
+struct TestFailure : public std::exception {
+    const char* what() const noexcept override { return "requirement failed"; }
+};
+} // namespace mini_catch
+
+#define TEST_CASE(name) \
+    void test_##name(); \
+    static mini_catch::AutoReg reg_##name(#name, test_##name); \
+    void test_##name()
+
+#define REQUIRE(cond) \
+    do { if (!(cond)) throw mini_catch::TestFailure(); } while (false)
+
+#ifdef CATCH_CONFIG_MAIN
+int main() {
+    return mini_catch::registry().run();
+}
+#endif

--- a/tests/test_check_guess.cpp
+++ b/tests/test_check_guess.cpp
@@ -1,0 +1,34 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+#include "../ufo_functions.hpp"
+
+TEST_CASE(check_guess_reveals_all_occurrences) {
+    std::string codeword = "letter";
+    std::string answer(codeword.size(), '_');
+    bool result = check_guess(codeword, answer, 't');
+    REQUIRE(result == true);
+    REQUIRE(answer == "__tt__");
+}
+
+TEST_CASE(check_guess_returns_false_when_letter_absent) {
+    std::string codeword = "letter";
+    std::string answer(codeword.size(), '_');
+    bool result = check_guess(codeword, answer, 'x');
+    REQUIRE(result == false);
+    REQUIRE(answer == "______");
+}
+
+TEST_CASE(check_guess_is_case_sensitive) {
+    std::string codeword = "Apple";
+    std::string answer(codeword.size(), '_');
+
+    // lowercase guess should not match uppercase codeword
+    bool lower_result = check_guess(codeword, answer, 'a');
+    REQUIRE(lower_result == false);
+    REQUIRE(answer == "_____");
+
+    // uppercase guess should match and reveal the letter
+    bool upper_result = check_guess(codeword, answer, 'A');
+    REQUIRE(upper_result == true);
+    REQUIRE(answer == "A____");
+}


### PR DESCRIPTION
## Summary
- create lightweight Catch2-style framework for running tests
- add test cases for `check_guess` covering repeated letters, absent letters, and case sensitivity
- integrate tests into build via a new Makefile and document usage

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68981a6c0cfc8326861811da4f95c0c1