### PR TITLE
Fix duplicate miss condition in display_misses

### DIFF
--- a/ufo_functions.cpp
+++ b/ufo_functions.cpp
@@ -99,23 +99,6 @@ void display_misses(int misses) {
     std::cout << "         /               \\                   \n";
 
   }
-  else if (misses == 3) {
-
-    std::cout << "                 .                            \n";
-    std::cout << "                 |                            \n";
-    std::cout << "              .-\"^\"-.                       \n";
-    std::cout << "             /_....._\\                       \n";
-    std::cout << "         .-\"`         `\"-.                  \n";
-    std::cout << "        (  ooo  ooo  ooo  )                   \n";
-    std::cout << "         '-.,_________,.-'    ,-----------.   \n";
-    std::cout << "              /--|--\\        (  Send help! ) \n";
-    std::cout << "             /   |   \\      / `-----------'  \n";
-    std::cout << "            /   / \\   \\    /                \n";
-    std::cout << "           /           \\                     \n";
-    std::cout << "          /             \\                    \n";
-    std::cout << "         /               \\                   \n";
-
-  }
   else if (misses == 4) {
 
     std::cout << "                 .                            \n";


### PR DESCRIPTION
## Summary
- remove redundant `misses == 3` block so each miss count has unique ascii art

## Testing
- `g++ ufo.cpp ufo_functions.cpp -std=c++17`


------
https://chatgpt.com/codex/tasks/task_e_689819091374832691845c1098f41829